### PR TITLE
feat: embed policies, add distribution packaging, CodeQL, and Docker support

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 3 * * 1' # Weekly on Monday at 03:27 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3.32.4
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3.32.4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3.32.4
+        with:
+          category: "/language:go"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,95 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
+sboms:
+  - artifacts: archive
+  - id: source
+    artifacts: source
+
+nfpms:
+  - id: deb
+    package_name: closedsspm
+    vendor: PiotrMackowski
+    homepage: https://github.com/PiotrMackowski/ClosedSSPM
+    maintainer: Piotr Mackowski <115957655+PiotrMackowski@users.noreply.github.com>
+    description: Open Source SaaS Security Posture Management — audit SaaS platforms for security misconfigurations.
+    license: Apache-2.0
+    formats:
+      - deb
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/closedsspm/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/closedsspm/README.md
+
+  - id: rpm
+    package_name: closedsspm
+    vendor: PiotrMackowski
+    homepage: https://github.com/PiotrMackowski/ClosedSSPM
+    maintainer: Piotr Mackowski <115957655+PiotrMackowski@users.noreply.github.com>
+    description: Open Source SaaS Security Posture Management — audit SaaS platforms for security misconfigurations.
+    license: Apache-2.0
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/closedsspm/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/closedsspm/README.md
+
+dockers:
+  - id: closedsspm-amd64
+    ids:
+      - closedsspm
+      - closedsspm-mcp
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-amd64"
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.title=ClosedSSPM"
+      - "--label=org.opencontainers.image.description=Open Source SaaS Security Posture Management"
+      - "--label=org.opencontainers.image.url=https://github.com/PiotrMackowski/ClosedSSPM"
+      - "--label=org.opencontainers.image.source=https://github.com/PiotrMackowski/ClosedSSPM"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+      - "--platform=linux/amd64"
+
+  - id: closedsspm-arm64
+    ids:
+      - closedsspm
+      - closedsspm-mcp
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-arm64"
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.title=ClosedSSPM"
+      - "--label=org.opencontainers.image.description=Open Source SaaS Security Posture Management"
+      - "--label=org.opencontainers.image.url=https://github.com/PiotrMackowski/ClosedSSPM"
+      - "--label=org.opencontainers.image.source=https://github.com/PiotrMackowski/ClosedSSPM"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-amd64"
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/piotrmackowski/closedsspm:latest"
+    image_templates:
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-amd64"
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-arm64"
+
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata
+
+COPY closedsspm /usr/local/bin/closedsspm
+COPY closedsspm-mcp /usr/local/bin/closedsspm-mcp
+
+USER nobody:nobody
+
+ENTRYPOINT ["closedsspm"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-mcp clean test lint run-checks help
+.PHONY: build build-mcp clean test vet lint run-checks docker snapshot-check tidy help
 
 BINARY=closedsspm
 MCP_BINARY=closedsspm-mcp
@@ -20,11 +20,15 @@ all: build build-mcp
 
 ## clean: Remove build artifacts
 clean:
-	rm -rf bin/
+	rm -rf bin/ dist/
 
 ## test: Run all tests
 test:
-	go test -v -race ./...
+	go test -v -count=1 ./...
+
+## vet: Run go vet
+vet:
+	go vet ./...
 
 ## lint: Run linter
 lint:
@@ -33,6 +37,14 @@ lint:
 ## run-checks: List all available security checks
 run-checks: build
 	./bin/$(BINARY) checks list
+
+## snapshot-check: Validate goreleaser config
+snapshot-check:
+	goreleaser check
+
+## docker: Build Docker image locally
+docker:
+	docker build -t closedsspm:local .
 
 ## tidy: Clean up go.mod and go.sum
 tidy:

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/PiotrMackowski/ClosedSSPM/internal/collector"
 	"github.com/PiotrMackowski/ClosedSSPM/internal/finding"
+	"github.com/PiotrMackowski/ClosedSSPM/policies"
 )
 
 func TestLoadPolicies(t *testing.T) {
@@ -413,5 +414,30 @@ func TestEvaluateDisplayValueObject(t *testing.T) {
 	// The display_value "admin" should match the contains condition.
 	if len(findings) != 1 {
 		t.Errorf("Display value object should match, got %d findings, want 1", len(findings))
+	}
+}
+
+func TestLoadPoliciesFS(t *testing.T) {
+	// Load from embedded filesystem.
+	pols, err := LoadPoliciesFS(policies.Embedded, ".")
+	if err != nil {
+		t.Fatalf("LoadPoliciesFS() error: %v", err)
+	}
+
+	if len(pols) != 40 {
+		t.Errorf("LoadPoliciesFS() returned %d policies, want 40", len(pols))
+	}
+
+	// Verify all policies have required fields.
+	for _, p := range pols {
+		if p.ID == "" {
+			t.Error("Embedded policy has empty ID")
+		}
+		if p.Title == "" {
+			t.Errorf("Embedded policy %s has empty Title", p.ID)
+		}
+		if p.Severity == "" {
+			t.Errorf("Embedded policy %s has empty Severity", p.ID)
+		}
 	}
 }

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -1,0 +1,9 @@
+// Package policies embeds the built-in policy YAML files into the binary.
+package policies
+
+import "embed"
+
+// Embedded contains all built-in policy YAML files.
+//
+//go:embed servicenow/*.yaml
+var Embedded embed.FS


### PR DESCRIPTION
## Summary

Embeds policy YAML files into binaries using Go's `embed` package, adds distribution packaging (deb/rpm/Docker), CodeQL security scanning, and updates README with badges and installation docs.

## Changes

### Embedded Policies
- New `policies/policies.go` with `//go:embed servicenow/*.yaml` directive
- New `LoadPoliciesFS(fs.FS, root)` function in policy engine
- Both binaries (`closedsspm`, `closedsspm-mcp`) try disk-based policies first, fall back to embedded
- New test `TestLoadPoliciesFS` (72 tests total, all passing)

### Distribution Packaging (`.goreleaser.yml`)
- **SBOM**: `artifacts: archive` + `artifacts: source` for supply chain transparency
- **nfpms**: `.deb` and `.rpm` packages with proper metadata and docs
- **Docker**: Multi-arch images (amd64/arm64) on GHCR with OCI labels
- **Docker manifests**: `latest` + versioned tags

### Security
- **CodeQL workflow** (`.github/workflows/codeql.yml`): SHA-pinned to `v3.32.4`, weekly schedule + PR triggers, concurrency groups

### Infrastructure
- **Dockerfile**: Alpine 3.21 base, runs as `nobody`, copies pre-built binaries
- **Makefile**: New `vet`, `docker`, `snapshot-check` targets; `clean` includes `dist/`

### Documentation
- **README**: 6 shields.io badges (CI, CodeQL, Go Report Card, License, Go Version, Release), full installation methods (binary, deb, rpm, Docker, source), all 40 checks in collapsible table, embedded policies documentation

## Verification
- 72 tests pass (`go test ./...`)
- `go vet ./...` clean
- Both binaries compile and run
- Embedded policies verified: binary loads 40 checks from `/tmp` with no external policy dir