### PR TITLE
feat: optimize for public repo — embedded policies, Homebrew, CodeQL, distribution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,21 @@
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+    labels:
+      - dependencies
+      - go
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+    labels:
+      - dependencies
+      - ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,101 +1,53 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL Advanced"
+name: CodeQL
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    branches: [ "main" ]
+    branches: [main]
   schedule:
-    - cron: '25 3 * * 4'
+    - cron: '27 3 * * 1' # Weekly on Monday at 03:27 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: go
-          build-mode: autobuild
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+          - language: go
+            build-mode: autobuild
+          - language: actions
+            build-mode: none
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3.32.4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3.32.4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -35,3 +36,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,113 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
+sboms:
+  - artifacts: archive
+  - id: source
+    artifacts: source
+
+nfpms:
+  - id: deb
+    package_name: closedsspm
+    vendor: PiotrMackowski
+    homepage: https://github.com/PiotrMackowski/ClosedSSPM
+    maintainer: Piotr Mackowski <115957655+PiotrMackowski@users.noreply.github.com>
+    description: Open Source SaaS Security Posture Management — audit SaaS platforms for security misconfigurations.
+    license: Apache-2.0
+    formats:
+      - deb
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/closedsspm/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/closedsspm/README.md
+
+  - id: rpm
+    package_name: closedsspm
+    vendor: PiotrMackowski
+    homepage: https://github.com/PiotrMackowski/ClosedSSPM
+    maintainer: Piotr Mackowski <115957655+PiotrMackowski@users.noreply.github.com>
+    description: Open Source SaaS Security Posture Management — audit SaaS platforms for security misconfigurations.
+    license: Apache-2.0
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/closedsspm/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/closedsspm/README.md
+
+dockers:
+  - id: closedsspm-amd64
+    ids:
+      - closedsspm
+      - closedsspm-mcp
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-amd64"
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.title=ClosedSSPM"
+      - "--label=org.opencontainers.image.description=Open Source SaaS Security Posture Management"
+      - "--label=org.opencontainers.image.url=https://github.com/PiotrMackowski/ClosedSSPM"
+      - "--label=org.opencontainers.image.source=https://github.com/PiotrMackowski/ClosedSSPM"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+      - "--platform=linux/amd64"
+
+  - id: closedsspm-arm64
+    ids:
+      - closedsspm
+      - closedsspm-mcp
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-arm64"
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.title=ClosedSSPM"
+      - "--label=org.opencontainers.image.description=Open Source SaaS Security Posture Management"
+      - "--label=org.opencontainers.image.url=https://github.com/PiotrMackowski/ClosedSSPM"
+      - "--label=org.opencontainers.image.source=https://github.com/PiotrMackowski/ClosedSSPM"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-amd64"
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/piotrmackowski/closedsspm:latest"
+    image_templates:
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-amd64"
+      - "ghcr.io/piotrmackowski/closedsspm:{{ .Version }}-arm64"
+
+brews:
+  - repository:
+      owner: PiotrMackowski
+      name: homebrew-closedsspm
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/PiotrMackowski/ClosedSSPM
+    description: Open Source SaaS Security Posture Management — audit SaaS platforms for security misconfigurations.
+    license: Apache-2.0
+    commit_author:
+      name: Piotr Mackowski
+      email: 115957655+PiotrMackowski@users.noreply.github.com
+    install: |
+      bin.install "closedsspm"
+      bin.install "closedsspm-mcp"
+    test: |
+      system "#{bin}/closedsspm", "--version"
+
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata
+
+COPY closedsspm /usr/local/bin/closedsspm
+COPY closedsspm-mcp /usr/local/bin/closedsspm-mcp
+
+USER nobody:nobody
+
+ENTRYPOINT ["closedsspm"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-mcp clean test lint run-checks help
+.PHONY: build build-mcp clean test vet lint run-checks docker snapshot-check tidy help
 
 BINARY=closedsspm
 MCP_BINARY=closedsspm-mcp
@@ -20,11 +20,15 @@ all: build build-mcp
 
 ## clean: Remove build artifacts
 clean:
-	rm -rf bin/
+	rm -rf bin/ dist/
 
 ## test: Run all tests
 test:
-	go test -v -race ./...
+	go test -v -count=1 ./...
+
+## vet: Run go vet
+vet:
+	go vet ./...
 
 ## lint: Run linter
 lint:
@@ -33,6 +37,14 @@ lint:
 ## run-checks: List all available security checks
 run-checks: build
 	./bin/$(BINARY) checks list
+
+## snapshot-check: Validate goreleaser config
+snapshot-check:
+	goreleaser check
+
+## docker: Build Docker image locally
+docker:
+	docker build -t closedsspm:local .
 
 ## tidy: Clean up go.mod and go.sum
 tidy:

--- a/README.md
+++ b/README.md
@@ -1,24 +1,82 @@
 # ClosedSSPM
 
+[![CI](https://github.com/PiotrMackowski/ClosedSSPM/actions/workflows/ci.yml/badge.svg)](https://github.com/PiotrMackowski/ClosedSSPM/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/PiotrMackowski/ClosedSSPM/actions/workflows/codeql.yml/badge.svg)](https://github.com/PiotrMackowski/ClosedSSPM/actions/workflows/codeql.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/PiotrMackowski/ClosedSSPM)](https://goreportcard.com/report/github.com/PiotrMackowski/ClosedSSPM)
+[![License](https://img.shields.io/github/license/PiotrMackowski/ClosedSSPM)](LICENSE)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/PiotrMackowski/ClosedSSPM)](go.mod)
+[![Release](https://img.shields.io/github/v/release/PiotrMackowski/ClosedSSPM?include_prereleases)](https://github.com/PiotrMackowski/ClosedSSPM/releases)
+
 Open Source SaaS Security Posture Management (SSPM) tool. Audits SaaS platforms for security misconfigurations, starting with deep ServiceNow coverage.
 
 ## Features
 
-- **ServiceNow security auditing** - 10 built-in checks covering ACLs, roles, scripts, and more
-- **Policy-as-code** - Audit checks defined in YAML, easily extensible with custom policies
-- **HTML reports** - Self-contained, dark-themed HTML reports with posture scoring (A-F)
-- **JSON output** - Machine-readable output for pipeline integration
-- **MCP server** - AI-assisted audit analysis via Model Context Protocol (works with Claude, OpenCode, etc.)
-- **Offline analysis** - Collect data once, analyze many times with snapshot persistence
-- **Parallel collection** - Concurrent API requests with configurable rate limiting
+- **40 security checks** covering ACLs, roles, scripts, integrations, instance config, and users
+- **Policy-as-code** — audit checks defined in YAML, easily extensible with custom policies
+- **Embedded policies** — all checks are baked into the binary; no external files needed at runtime
+- **HTML reports** — self-contained, dark-themed HTML reports with posture scoring (A–F)
+- **JSON output** — machine-readable output for pipeline integration
+- **MCP server** — AI-assisted audit analysis via Model Context Protocol (works with Claude, OpenCode, etc.)
+- **Offline analysis** — collect data once, analyze many times with snapshot persistence
+- **Parallel collection** — concurrent API requests with configurable rate limiting
 
-## Quick Start
+## Installation
 
-### Build
+### Homebrew (macOS / Linux)
 
 ```bash
+brew tap PiotrMackowski/closedsspm
+brew install closedsspm
+```
+
+### Binary (GitHub Releases)
+
+Download the latest release for your platform from the [Releases](https://github.com/PiotrMackowski/ClosedSSPM/releases) page.
+
+```bash
+# Linux amd64
+curl -Lo closedsspm.tar.gz https://github.com/PiotrMackowski/ClosedSSPM/releases/latest/download/closedsspm_Linux_amd64.tar.gz
+tar xzf closedsspm.tar.gz
+sudo mv closedsspm closedsspm-mcp /usr/local/bin/
+```
+
+### Debian / Ubuntu (.deb)
+
+```bash
+# Download the .deb from the latest release
+sudo dpkg -i closedsspm_*.deb
+```
+
+### Red Hat / Fedora (.rpm)
+
+```bash
+# Download the .rpm from the latest release
+sudo rpm -i closedsspm_*.rpm
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/piotrmackowski/closedsspm:latest
+
+# Run an audit
+docker run --rm \
+  -e SNOW_INSTANCE=https://mycompany.service-now.com \
+  -e SNOW_USERNAME=audit_user \
+  -e SNOW_PASSWORD=secret \
+  -v "$(pwd):/out" \
+  ghcr.io/piotrmackowski/closedsspm:latest audit --output /out/report.html
+```
+
+### Build from Source
+
+```bash
+git clone https://github.com/PiotrMackowski/ClosedSSPM.git
+cd ClosedSSPM
 make all
 ```
+
+## Quick Start
 
 ### Run an Audit
 
@@ -29,24 +87,24 @@ export SNOW_USERNAME=audit_user
 export SNOW_PASSWORD=secret
 
 # Full audit: collect + evaluate + report
-./bin/closedsspm audit --output report.html
+closedsspm audit --output report.html
 
 # Or step by step:
-./bin/closedsspm collect --output snapshot.json
-./bin/closedsspm evaluate --snapshot snapshot.json --output report.html
+closedsspm collect --output snapshot.json
+closedsspm evaluate --snapshot snapshot.json --output report.html
 ```
 
 ### List Available Checks
 
 ```bash
-./bin/closedsspm checks list
+closedsspm checks list
 ```
 
 ### MCP Server (AI-Assisted Analysis)
 
 ```bash
 # Start MCP server with a snapshot
-./bin/closedsspm mcp --snapshot snapshot.json
+closedsspm mcp --snapshot snapshot.json
 ```
 
 Add to your MCP client configuration (e.g. Claude Desktop):
@@ -59,6 +117,14 @@ Add to your MCP client configuration (e.g. Claude Desktop):
     }
   }
 }
+```
+
+### Custom Policies Directory
+
+By default the binary uses its 40 embedded policies. To override with external policies:
+
+```bash
+closedsspm audit --policies /path/to/my/policies --output report.html
 ```
 
 ## Architecture
@@ -79,10 +145,24 @@ closedsspm/
 │       ├── html/           # HTML report generator
 │       └── json/           # JSON report generator
 └── policies/
-    └── servicenow/         # ServiceNow policy definitions (YAML)
+    └── servicenow/         # ServiceNow policy definitions (YAML, embedded at build)
 ```
 
-## Security Checks (v0.1)
+## Security Checks
+
+40 built-in checks across 6 categories:
+
+| Category | Count | Examples |
+|----------|-------|---------|
+| **ACL** | 8 | Unprotected ACLs, wildcard roles, public access |
+| **Roles** | 5 | Admin role assignments, elevated privileges, role includes |
+| **Scripts** | 6 | eval() usage, client-callable script includes, global UI scripts |
+| **Integrations** | 7 | Unauthenticated endpoints, basic auth, unvalidated MID servers |
+| **Instance Config** | 10 | HTTPS enforcement, session timeout, password policy, SAML signing |
+| **Users** | 4 | Never-logged-in accounts, locked-out active users |
+
+<details>
+<summary>Full check list</summary>
 
 | ID | Severity | Category | Description |
 |----|----------|----------|-------------|
@@ -96,6 +176,38 @@ closedsspm/
 | SNOW-ACL-008 | HIGH | ACL | ACL allows unauthenticated access via public type |
 | SNOW-ROLE-001 | HIGH | Roles | Users with admin role |
 | SNOW-ROLE-002 | CRITICAL | Roles | Integration/service users with admin role |
+| SNOW-ROLE-003 | HIGH | Roles | Roles with elevated privilege flag enabled |
+| SNOW-ROLE-004 | MEDIUM | Roles | Roles with no assignable_by restriction |
+| SNOW-ROLE-005 | CRITICAL | Roles | Custom role that includes the admin role |
+| SNOW-SCRIPT-001 | CRITICAL | Scripts | Business rule script uses eval() or GlideEvaluator |
+| SNOW-SCRIPT-002 | HIGH | Scripts | Script include marked as client-callable |
+| SNOW-SCRIPT-003 | HIGH | Scripts | Global UI script active and running for all users |
+| SNOW-SCRIPT-004 | LOW | Scripts | Active business rule with no description |
+| SNOW-SCRIPT-005 | MEDIUM | Scripts | Active before business rule modifying data on sensitive tables |
+| SNOW-SCRIPT-006 | LOW | Scripts | Active script include with no description |
+| SNOW-INT-001 | CRITICAL | Integrations | Web service endpoint with authentication disabled |
+| SNOW-INT-002 | LOW | Integrations | Inactive web service endpoint still defined |
+| SNOW-INT-003 | HIGH | Integrations | REST message using basic authentication |
+| SNOW-INT-004 | INFO | Integrations | Active OAuth application registered |
+| SNOW-INT-005 | HIGH | Integrations | MID Server not in validated status |
+| SNOW-INT-006 | HIGH | Integrations | Scripted REST operation without ACL authorization |
+| SNOW-INT-007 | MEDIUM | Integrations | Scripted REST operation contains eval() or GlideRecord in script |
+| SNOW-CFG-001 | CRITICAL | Instance Config | Instance allows HTTP connections (HTTPS not enforced) |
+| SNOW-CFG-002 | HIGH | Instance Config | Session timeout set too high or unlimited |
+| SNOW-CFG-003 | HIGH | Instance Config | Password policy does not enforce complexity |
+| SNOW-CFG-004 | MEDIUM | Instance Config | Debug mode or logging verbosity enabled in production |
+| SNOW-CFG-005 | MEDIUM | Instance Config | High security plugin not activated |
+| SNOW-CFG-006 | MEDIUM | Instance Config | IP address access control not configured |
+| SNOW-CFG-007 | HIGH | Instance Config | SSL certificate approaching expiration or already expired |
+| SNOW-CFG-008 | CRITICAL | Instance Config | LDAP server connection without SSL/TLS encryption |
+| SNOW-CFG-009 | CRITICAL | Instance Config | SAML identity provider with unsigned assertions |
+| SNOW-CFG-010 | HIGH | Instance Config | SAML identity provider using weak signing algorithm |
+| SNOW-USER-001 | MEDIUM | Users | Active user account that has never logged in |
+| SNOW-USER-002 | HIGH | Users | Locked out user account still active |
+| SNOW-USER-003 | MEDIUM | Users | User account sourced from external directory but active |
+| SNOW-USER-004 | INFO | Users | Internal integration user account is active |
+
+</details>
 
 ## MCP Tools
 
@@ -111,9 +223,9 @@ closedsspm/
 ## Security Best Practices
 
 - Credentials are **only** read from environment variables, never from config files
-- Snapshots may contain sensitive data - treat them as confidential
+- Snapshots may contain sensitive data — treat them as confidential
 - The MCP server uses **stdio transport only** (no network exposure)
-- The tool is **read-only** - it never writes to your ServiceNow instance
+- The tool is **read-only** — it never writes to your ServiceNow instance
 - ServiceNow audit user should have **read-only** roles (minimum required permissions)
 
 ### Minimum ServiceNow Permissions
@@ -147,4 +259,4 @@ references:
 
 ## License
 
-Apache 2.0 - see [LICENSE](LICENSE)
+Apache 2.0 — see [LICENSE](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,60 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| 0.x.x   | :white_check_mark: |
+
+Security updates are applied to the latest release only. We recommend always running the most recent version.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+**Please do NOT report security vulnerabilities through public GitHub issues.**
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Instead, use [GitHub Security Advisories](https://github.com/PiotrMackowski/ClosedSSPM/security/advisories/new) to report vulnerabilities privately.
+
+You should receive an initial response within **72 hours**. If the issue is confirmed, a fix will be released as soon as possible, typically within **7 days** depending on complexity.
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected version(s)
+- Potential impact assessment
+
+### What to Expect
+
+- Acknowledgment within 72 hours
+- Regular updates on remediation progress
+- Credit in the release notes (unless you prefer anonymity)
+- CVE assignment for confirmed vulnerabilities where appropriate
+
+## Security Design
+
+ClosedSSPM is designed with security as a core principle:
+
+- **Read-only by design** — the tool never writes to audited SaaS instances
+- **No credential storage** — credentials are only read from environment variables, never persisted to disk or config files
+- **Stdio-only MCP transport** — the MCP server uses stdio transport exclusively, with no network exposure
+- **Input validation** — all MCP inputs are validated against strict patterns (length limits, regex allowlists)
+- **No eval or dynamic code execution** — policies are declarative YAML, never executed as code
+- **Dependency minimalism** — minimal third-party dependencies to reduce supply chain risk
+- **SBOM generation** — every release includes a Software Bill of Materials
+- **SHA-pinned CI** — all GitHub Actions are pinned to full commit SHAs
+
+## Dependency Management
+
+Dependencies are monitored by:
+
+- **Dependabot** — automated version update PRs for Go modules and GitHub Actions
+- **CodeQL** — weekly static analysis scanning
+- **Go vulnerability database** — checked via `govulncheck` (planned)
+
+## Snapshot Data Handling
+
+Snapshots collected by ClosedSSPM may contain sensitive configuration data from your SaaS instance. Treat snapshot files as confidential:
+
+- Do not commit snapshots to version control
+- Do not share snapshots in public channels
+- Delete snapshots after analysis is complete
+- Store snapshots with appropriate filesystem permissions

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/PiotrMackowski/ClosedSSPM/internal/collector"
 	"github.com/PiotrMackowski/ClosedSSPM/internal/finding"
+	"github.com/PiotrMackowski/ClosedSSPM/policies"
 )
 
 func TestLoadPolicies(t *testing.T) {
@@ -413,5 +414,30 @@ func TestEvaluateDisplayValueObject(t *testing.T) {
 	// The display_value "admin" should match the contains condition.
 	if len(findings) != 1 {
 		t.Errorf("Display value object should match, got %d findings, want 1", len(findings))
+	}
+}
+
+func TestLoadPoliciesFS(t *testing.T) {
+	// Load from embedded filesystem.
+	pols, err := LoadPoliciesFS(policies.Embedded, ".")
+	if err != nil {
+		t.Fatalf("LoadPoliciesFS() error: %v", err)
+	}
+
+	if len(pols) != 40 {
+		t.Errorf("LoadPoliciesFS() returned %d policies, want 40", len(pols))
+	}
+
+	// Verify all policies have required fields.
+	for _, p := range pols {
+		if p.ID == "" {
+			t.Error("Embedded policy has empty ID")
+		}
+		if p.Title == "" {
+			t.Errorf("Embedded policy %s has empty Title", p.ID)
+		}
+		if p.Severity == "" {
+			t.Errorf("Embedded policy %s has empty Severity", p.ID)
+		}
 	}
 }

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -1,0 +1,9 @@
+// Package policies embeds the built-in policy YAML files into the binary.
+package policies
+
+import "embed"
+
+// Embedded contains all built-in policy YAML files.
+//
+//go:embed servicenow/*.yaml
+var Embedded embed.FS


### PR DESCRIPTION
## Summary

Optimizes the repo for its new public status: embeds policies into binaries, adds Homebrew tap, replaces GitHub-template files with proper configurations, and adds full distribution packaging.

## Changes

### Embedded Policies
- New `policies/policies.go` with `//go:embed servicenow/*.yaml`
- New `LoadPoliciesFS(fs.FS, root)` in policy engine — binary tries disk first, falls back to embedded
- Both `closedsspm` and `closedsspm-mcp` support embedded fallback
- New `TestLoadPoliciesFS` test (72 tests total)

### Homebrew Tap
- Created [`homebrew-closedsspm`](https://github.com/PiotrMackowski/homebrew-closedsspm) tap repo
- Added `brews` section to `.goreleaser.yml` — auto-publishes formula on release
- Requires `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT with `contents: write` on tap repo)
- Users install via `brew tap PiotrMackowski/closedsspm && brew install closedsspm`

### CodeQL Workflow (replaces GitHub template)
- SHA-pinned to commit `45580472a5bb82c4681c4ac726cfdb60060c2ee1` (v3.32.4)
- Matrix strategy scanning **Go** + **Actions** languages
- Concurrency groups, weekly schedule, lean (no boilerplate comments)
- Go setup step with `go-version-file: go.mod`

### Dependabot (replaces empty template)
- `gomod` ecosystem — weekly Go dependency updates
- `github-actions` ecosystem — weekly action SHA updates
- Commit prefixes (`deps:`, `ci:`) and labels

### SECURITY.md (replaces GitHub template)
- Supported versions table (v0.x.x)
- GitHub Security Advisories for private vulnerability reporting
- 72-hour response SLA
- Security design principles (read-only, no credential storage, stdio-only MCP, etc.)
- Snapshot data handling guidance

### Distribution Packaging
- **SBOM**: archive + source artifacts
- **nfpms**: `.deb` and `.rpm` packages
- **Docker**: Multi-arch (amd64/arm64) on GHCR with OCI labels + manifests
- **Dockerfile**: Alpine 3.21, runs as `nobody`

### Release Workflow
- Added `packages: write` permission (for GHCR Docker push)
- Added `HOMEBREW_TAP_TOKEN` env var for Homebrew formula publishing

### README
- Added Homebrew install section (first install method listed)
- 6 shields.io badges (CI, CodeQL, Go Report Card, License, Go Version, Release)
- Full installation docs (Homebrew, binary, deb, rpm, Docker, source)

## Setup Required After Merge

1. **Create `HOMEBREW_TAP_TOKEN` secret** in repo Settings → Secrets → Actions:
   - Create a fine-grained PAT at github.com/settings/tokens with `contents: write` for `homebrew-closedsspm`
   - Add as repository secret named `HOMEBREW_TAP_TOKEN`

2. **Tag `v0.1.0`** to trigger the release workflow:
   ```bash
   git tag v0.1.0
   git push origin v0.1.0
   ```

## Verification
- ✅ 72 tests pass (`go test ./...`)
- ✅ `go vet ./...` clean
- ✅ Both binaries compile
- ✅ Embedded policies load correctly (40 checks from binary)