### PR TITLE
fix: use correct SHA for OpenSSF Scorecard action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- Fix Scorecard workflow failure by using the dereferenced **commit SHA** (`4eaacf05`) instead of the annotated **tag object SHA** (`99c09fe9`) for `ossf/scorecard-action@v2.4.3`
- The Scorecard webapp verification rejects tag object SHAs with: `imposter commit does not belong to ossf/scorecard-action`

Both SHAs resolve to the same code — the tag object just wraps the commit with metadata. GitHub Actions handles both, but the Scorecard webapp's verification endpoint only accepts commit SHAs.