### PR TITLE
fix: resolve 24 code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +16,8 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,10 +8,7 @@ on:
   schedule:
     - cron: '27 3 * * 1' # Weekly on Monday at 03:27 UTC
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +18,10 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,17 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
-  attestations: write
+permissions: read-all
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,9 +8,7 @@ on:
   schedule:
     - cron: '30 5 * * 1' # Weekly on Monday at 05:30 UTC
 
-permissions:
-  contents: read
-  security-events: write
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +18,9 @@ jobs:
   trivy:
     name: Trivy Image Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.21@sha256:22e0ec13c0db6b3e1ba3280e831fc50ba7bffe58e81f31670a64b1afede247bc
 
 RUN apk add --no-cache ca-certificates tzdata
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PiotrMackowski/ClosedSSPM
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/mark3labs/mcp-go v0.44.1


### PR DESCRIPTION
## Summary

Resolves **24 of 30** open code scanning alerts. The remaining 6 are project-level Scorecard findings that require manual GitHub Settings or external enrollment (not code changes).

### Changes

**Go 1.24.0 → 1.24.13** (fixes 19 Trivy CVEs)
- 4 HIGH: CVE-2025-61730 (TLS 1.3), CVE-2025-61729 (x509), CVE-2025-61728 (archive/zip), CVE-2025-61726 (net/url)
- 15 MEDIUM: CVE-2025-61727, CVE-2025-61725, CVE-2025-61724, CVE-2025-61723, CVE-2025-58189, CVE-2025-58188, CVE-2025-58187, CVE-2025-58186, CVE-2025-58185, CVE-2025-47912, CVE-2025-47906, CVE-2025-4673, CVE-2025-22873, CVE-2025-22871, CVE-2025-0913

**Workflow permissions hardened** (fixes 4 Scorecard Token-Permissions alerts)
- All workflows: top-level `permissions: read-all`
- Elevated permissions moved to job level only (principle of least privilege)
- Affected: `ci.yml`, `codeql.yml`, `release.yml`, `trivy.yml`

**Dockerfile pinned by digest** (fixes 1 Scorecard Pinned-Dependencies alert)
- `alpine:3.21` → `alpine:3.21@sha256:22e0ec13c0db6b3e1ba3280e831fc50ba7bffe58e81f31670a64b1afede247bc`

### Not addressed (require manual action)
| Alert | Why | Fix |
|-------|-----|-----|
| Branch-Protection | GitHub Settings | Enable branch protection rules on `main` |
| Code-Review | Process | PRs need reviewer approval history |
| Maintained | Time | Requires sustained commit activity |
| CII-Best-Practices | Enrollment | Register at https://www.bestpractices.dev |
| SAST | Auto-resolves | CodeQL already running, needs more history |
| Fuzzing | Enrollment | Register with OSS-Fuzz |