### PR TITLE
docs: add OpenSSF Baseline badge and Subprojects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License](https://img.shields.io/github/license/PiotrMackowski/ClosedSSPM)](LICENSE)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/PiotrMackowski/ClosedSSPM)](go.mod)
 [![Release](https://img.shields.io/github/v/release/PiotrMackowski/ClosedSSPM?include_prereleases)](https://github.com/PiotrMackowski/ClosedSSPM/releases)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12061/baseline)](https://www.bestpractices.dev/projects/12061)
 
 Open Source SaaS Security Posture Management (SSPM) tool. Audits SaaS platforms for security misconfigurations, starting with deep ServiceNow coverage.
 


### PR DESCRIPTION
## Summary

- Add OpenSSF Baseline Level 1 badge to README header
- Add Subprojects section documenting the `homebrew-closedsspm` tap repository (required by OSPS-QA-04.01)

These were committed after PR #14 was merged and need a separate PR.