### PR TITLE
fix(ci): add Docker Buildx and GHCR login for multi-platform image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,19 @@ jobs:
       - name: Install Syft
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.42.1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:


### PR DESCRIPTION
## Summary

- Fixes the failing Docker image build in the release workflow ([run #22525991286](https://github.com/PiotrMackowski/ClosedSSPM/actions/runs/22525991286))
- Adds **QEMU**, **Docker Buildx**, and **GHCR login** steps before GoReleaser runs

## Problem

GoReleaser's `dockers_v2` uses `docker buildx build --attest=type=sbom`, which requires the `docker-container` buildx driver. The default `docker` driver on GitHub Actions runners does not support attestations, causing the release to fail with:

```
ERROR: failed to build: Attestation is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

## Fix

Three new steps added to `release.yml` (before GoReleaser):

| Step | Action | Purpose |
|------|--------|---------|
| Set up QEMU | `docker/setup-qemu-action@v3.7.0` | Cross-platform emulation (arm64 on amd64 runner) |
| Set up Docker Buildx | `docker/setup-buildx-action@v3.12.0` | Creates `docker-container` driver that supports attestations |
| Log in to GHCR | `docker/login-action@v3.7.0` | Authenticates so buildx can `--push` to `ghcr.io` |

All action references are pinned by SHA, consistent with existing workflow style.

## Testing

After merging, delete the failed `v0.1.0` release and re-tag to trigger a clean release.