### PR TITLE
fix(release): update cosign signing for v3 bundle format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,20 +60,17 @@ sboms:
 
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     artifacts: checksum
-    output: true
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
 
 docker_signs:
   - cmd: cosign
     artifacts: all
-    output: true
     args:
       - "sign"
       - "${artifact}"


### PR DESCRIPTION
## Summary

- Updates GoReleaser `signs` section to use cosign v3 `--bundle` flag instead of deprecated `--output-certificate` / `--output-signature` flags
- Removes `output: true` from `docker_signs` (unnecessary)

## Why

v0.2.0 release failed because CI installs cosign v3.0.2 which removed the v2 signing flags:
```
Error: must provide --bundle with --signing-config or --use-signing-config
```

The fix follows the pattern used by [sigstore/cosign's own goreleaser config](https://github.com/sigstore/cosign/blob/main/.goreleaser.yml).

## Changes

```yaml
# Before (cosign v2)
signs:
  - cmd: cosign
    certificate: "${artifact}.pem"
    artifacts: checksum
    output: true
    args:
      - sign-blob
      - "--output-certificate=${certificate}"
      - "--output-signature=${signature}"
      - "${artifact}"
      - "--yes"

# After (cosign v3)
signs:
  - cmd: cosign
    signature: "${artifact}.bundle"
    artifacts: checksum
    args:
      - sign-blob
      - "--bundle=${signature}"
      - "${artifact}"
      - "--yes"
```