### PR TITLE
fix: upgrade pymdown-extensions to 10.21.2 for Pygments 2.20.0 compatibility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -321,9 +321,9 @@ platformdirs==4.9.4 \
 pygments==2.20.0 \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via mkdocs-material
-pymdown-extensions==10.21 \
-    --hash=sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5 \
-    --hash=sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f
+pymdown-extensions==10.21.2 \
+    --hash=sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638 \
+    --hash=sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc
     # via mkdocs-material
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \


### PR DESCRIPTION
## Summary\n\n- Upgrades `pymdown-extensions` from 10.21 to 10.21.2 to fix compatibility with Pygments 2.20.0\n\n## Context\n\nThe Pygments 2.20.0 upgrade (merged in #85 to fix CVE-2026-4539) introduced a breaking change where `None` filename values cause `AttributeError` in `html.escape()`. pymdown-extensions 10.21.2 explicitly handles this case.\n\nRef: https://github.com/facelessuser/pymdown-extensions/issues/2863