### PR TITLE
fix: bump Go 1.26.3 → 1.26.4 to resolve stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PiotrMackowski/ClosedSSPM
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
Bumps Go toolchain from 1.26.3 to 1.26.4 to fix 3 stdlib CVEs causing Trivy Image Scan failures:\n\n- **CVE-2026-42504** (HIGH)\n- **CVE-2026-27145** (HIGH)\n- **CVE-2026-42507** (MEDIUM)\n\nAll three are fixed in Go 1.26.4.